### PR TITLE
Add OigViewModelResolver for resolving viewModels

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -46,6 +46,7 @@
 <script src="src/oig/observercontext.js"></script>
 <script src="src/oig/resource.js"></script>
 <script src="src/oig/templateengines.js"></script>
+<script src="src/oig/viewmodelresolver.js"></script>
 <script src="src/oig/element.js"></script>
 <script src="src/oig/elements/bindingelement.js"></script>
 <script src="src/oig/elements/contextelement.js"></script>

--- a/app/partials/binding/parent.html
+++ b/app/partials/binding/parent.html
@@ -1,14 +1,13 @@
 <div>
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        name: 'Daffy Duck',
-        color: 'red'
-      };
-      Object.defineProperty(oig.viewModels, 'parentBinding', {
-        get: function () {
-          return viewModel;
-        }
+      oig.locator.register('parentBinding', function () {
+        var viewModel = {
+          name: 'Daffy Duck',
+          color: 'red'
+        };
+
+        return viewModel;
       });
     }())
   </script>

--- a/app/partials/binding/previoussibling.html
+++ b/app/partials/binding/previoussibling.html
@@ -1,14 +1,13 @@
 <div>
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        width: 400,
-        img: 'assets/images/daffyduck.png'
-      };
-      Object.defineProperty(oig.viewModels, 'previousSiblingBinding', {
-        get: function () {
-          return viewModel;
-        }
+      oig.locator.register('previousSiblingBinding', function () {
+        var viewModel = {
+          width: 400,
+          img: 'assets/images/daffyduck.png'
+        };
+
+        return viewModel;
       });
     }())
   </script>

--- a/app/partials/binding/twoway-manual.html
+++ b/app/partials/binding/twoway-manual.html
@@ -1,16 +1,15 @@
 <div>
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        color: '#000',
-        name: 'Daffy Duck'
-      };
-      Object.defineProperty(oig.viewModels, 'twoWayBinding', {
-        get: function () {
-          return viewModel;
-        }
+      oig.locator.register('twoWayBinding', function() {
+        var viewModel = {
+          color: '#000',
+          name: 'Daffy Duck'
+        };
+
+        return viewModel;
       });
-    }())
+    }());
   </script>
   <div is="oig-context" data-view-model="twoWayBinding">
     <div class="form-group">

--- a/app/partials/binding/twoway-nextsibling.html
+++ b/app/partials/binding/twoway-nextsibling.html
@@ -1,14 +1,13 @@
 <div>
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        width: 200,
-        img: 'assets/images/daffyduck.png'
-      };
-      Object.defineProperty(oig.viewModels, 'twoWayNextSiblingBinding', {
-        get: function () {
-          return viewModel;
-        }
+      oig.locator.register('twoWayNextSiblingBinding', function () {
+        var viewModel = {
+          width: 200,
+          img: 'assets/images/daffyduck.png'
+        };
+
+        return viewModel;
       });
     }())
   </script>

--- a/app/partials/context/example.txt
+++ b/app/partials/context/example.txt
@@ -1,12 +1,11 @@
 <script type="text/javascript">
   (function () {
-    var viewModel = {
-      ... define properties here
-    };
-    Object.defineProperty(oig.viewModels, 'myViewModel', {
-      get: function () {
-        return viewModel;
-      }
+    oig.locator.register('myViewModel', function () {
+      var viewModel = {
+        ... define properties here
+      };
+
+      return viewModel;
     });
   }())
 </script>

--- a/app/partials/if/example.html
+++ b/app/partials/if/example.html
@@ -1,18 +1,17 @@
 <div xmlns="http://www.w3.org/1999/xhtml">
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        flag: true,
-        toggle: function () {
-          this.flag = !this.flag;
-        }
-      };
-      Object.defineProperty(oig.viewModels, 'ifBinding', {
-        get: function () {
-          return viewModel;
-        }
+      oig.locator.register('ifBinding', function () {
+        var viewModel = {
+          flag: true,
+          toggle: function () {
+            this.flag = !this.flag;
+          }
+        };
+
+        return viewModel;
       });
-    }())
+    }());
   </script>
   <div is="oig-context" data-view-model="ifBinding">
     <div class="alert alert-info">

--- a/app/partials/listener/example.html
+++ b/app/partials/listener/example.html
@@ -1,23 +1,22 @@
 <div xmlns="http://www.w3.org/1999/xhtml">
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        clickCountA: 0,
-        clickCountB: 0,
+      oig.locator.register('listenerExample', function () {
+        var viewModel = {
+          clickCountA: 0,
+          clickCountB: 0,
 
-        methodA: function () {
-          this.clickCountA++;
-        },
-        methodB: function () {
-          this.clickCountB++;
-        }
-      };
-      Object.defineProperty(oig.viewModels, 'listenerExample', {
-        get: function () {
-          return viewModel;
-        }
+          methodA: function () {
+            this.clickCountA++;
+          },
+          methodB: function () {
+            this.clickCountB++;
+          }
+        };
+
+        return viewModel;
       });
-    }())
+    }());
   </script>
   <div is="oig-context" data-view-model="listenerExample">
     <oig-listener onclick="methodA()" selector="button > span:first-child" prevent-default></oig-listener>

--- a/app/partials/observercontext/example.html
+++ b/app/partials/observercontext/example.html
@@ -1,22 +1,21 @@
 <div>
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        frozen: {
-          name: 'Daffy Duck'
-        },
-        hot: {
-          name: 'Garfield'
-        }
-      };
 
-      Object.freeze(viewModel.frozen);
+      oig.locator.register('observerContext', function () {
+        var viewModel = {
+          frozen: {
+            name: 'Daffy Duck'
+          },
+          hot: {
+            name: 'Garfield'
+          }
+        };
+        Object.freeze(viewModel.frozen);
 
-      Object.defineProperty(oig.viewModels, 'observerContext', {
-        get: function () {
-          return viewModel;
-        }
+        return viewModel;
       });
+
     }())
   </script>
   <div class="form-group" is="oig-context" data-view-model="observerContext">
@@ -43,3 +42,4 @@
       </div>
     </div>
   </div>
+</div>

--- a/app/partials/react/example.html
+++ b/app/partials/react/example.html
@@ -23,16 +23,15 @@
   </script>
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        count: 0,
-        increment: function () {
-          this.count++;
-        }
-      };
-      Object.defineProperty(oig.viewModels, 'reactBinding', {
-        get: function () {
-          return viewModel;
-        }
+      oig.locator.register('reactBinding', function () {
+        var viewModel = {
+          count: 0,
+          increment: function () {
+            this.count++;
+          }
+        };
+
+        return viewModel;
       });
     }())
   </script>

--- a/app/partials/template/example.html
+++ b/app/partials/template/example.html
@@ -1,14 +1,13 @@
 <div>
   <script type="text/javascript">
     (function () {
-      var viewModel = {
-        name: 'I am a templated viewModel',
-        items: [{id: 0, name: "John Doe"}, {id: 1, name: "Jane Doe"}]
-      };
-      Object.defineProperty(oig.viewModels, 'template', {
-        get: function () {
-          return viewModel;
-        }
+      oig.locator.register('template', function () {
+        var viewModel = {
+          name: 'I am a templated viewModel',
+          items: [{id: 0, name: "John Doe"}, {id: 1, name: "Jane Doe"}]
+        };
+
+        return viewModel;
       });
     }())
   </script>
@@ -56,3 +55,4 @@
       </div>
     </div>
   </div>
+</div>

--- a/app/src/oig/elements/contextelement.js
+++ b/app/src/oig/elements/contextelement.js
@@ -46,14 +46,14 @@ var OigContextElement = document.registerElement('oig-context', {
     attachedCallback: {
       value: function () {
         var viewModel = this.dataset.viewModel,
-          dataContext = null;
+          dataContext = null,
+          viewModelResolver = oig.locator.resolve('oigViewModelResolver');
         if (!viewModel) {
           throw '[oig:contextelement] required attribute data-view-model is missing';
         }
-        if (oig.viewModels.hasOwnProperty(viewModel)) {
-          dataContext = oig.viewModels[viewModel];
-        }
-        if (!dataContext) {
+        try {
+          dataContext = viewModelResolver.resolve(viewModel);
+        } catch (e) {
           throw '[oig:contextelement] no data context found for:' + viewModel;
         }
         this.dataContext = dataContext;

--- a/app/src/oig/module/module.js
+++ b/app/src/oig/module/module.js
@@ -16,6 +16,12 @@
     return new OigObserver(oigLocator.resolve('oigObserverContext'));
   });
 
+  oigLocator.register('oigViewModelResolver', function() {
+    return OigViewModelResolver;
+  });
+
+  oig.locator = oigLocator;
+
   // export the elements
   window.OigBindingElement = OigBindingElement;
   window.OigContextElement = OigContextElement;

--- a/app/src/oig/viewmodelresolver.js
+++ b/app/src/oig/viewmodelresolver.js
@@ -1,0 +1,19 @@
+/**
+ * Wrapper around oig locator for resolving view models
+ */
+var OigViewModelResolver = (function () {
+  'use strict';
+
+  /**
+   *
+   * @param {string} name
+   * @returns {Object}
+   */
+  function resolve(name) {
+    return oigLocator.resolve(name);
+  }
+
+  return {
+    resolve: resolve
+  }
+}());

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -24,7 +24,7 @@ module.exports = function(config) {
       'app/src/oig/*.js',
       {pattern: 'app/src/oig/**/*.js'},
       'test/mocks.js',
-      {pattern: 'test/spec/**/*Spec.js'},
+      {pattern: 'test/spec/**/*Spec.js'}
     ],
 
     coverageReporter: {

--- a/test/mocks.js
+++ b/test/mocks.js
@@ -20,6 +20,7 @@ var OigMockElement = document.registerElement('oig-mock', {
 
   var oigResourceMock = setUpMock(OigResource.prototype);
   var oigObserverMock = setUpMock(new OigObserver());
+  var oigViewModelResolverMock = setUpMock(OigViewModelResolver);
 
   oigLocator.register('oigResource', function () {
     return oigResourceMock;
@@ -27,6 +28,10 @@ var OigMockElement = document.registerElement('oig-mock', {
 
   oigLocator.register('oigObserver', function () {
     return oigObserverMock;
+  });
+
+  oigLocator.register('oigViewModelResolver', function () {
+    return oigViewModelResolverMock;
   });
 
 }())

--- a/test/spec/oig/datacontextSpec.js
+++ b/test/spec/oig/datacontextSpec.js
@@ -11,20 +11,28 @@ describe('datacontext', function () {
   var child;
 
   /**
-   * @type {Objecgt}
+   * @type {Object}
    */
   var viewModel;
 
+  /**
+   * @type {Object}
+   */
+  var oigViewModelResolver;
+
+  /**
+   * @type {Object}
+   */
+  var sandbox;
+
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
+    viewModel = {};
+    oigViewModelResolver = oigLocator.resolve('oigViewModelResolver');
+    sandbox.stub(oigViewModelResolver, 'resolve').returns(viewModel);
+  });
 
   beforeEach(function (done) {
-
-    viewModel = {};
-
-
-    Object.defineProperty(oig.viewModels, 'my', {
-      value: viewModel
-    });
-
     node = new OigContextElement();
     node.setAttribute('data-view-model', 'my');
     child = document.createElement('div');
@@ -34,7 +42,12 @@ describe('datacontext', function () {
   });
 
   afterEach(function () {
+    sandbox.restore();
     document.body.removeChild(node);
+  });
+
+  it('should call resolver for the context', function () {
+    expect(oigViewModelResolver.resolve.calledWith('my')).to.be.true;
   });
 
   it('should resolve the context', function () {

--- a/test/spec/oig/elements/bindingelementSpec.js
+++ b/test/spec/oig/elements/bindingelementSpec.js
@@ -19,18 +19,18 @@ describe('binding element', function () {
   var viewModel;
 
   /**
-   *
+   * @type {Object}
    */
-  var objectObserver;
+  var oigViewModelResolver;
+
+  /**
+   * @type {Object}
+   */
+  var sandbox;
 
   before(function () {
-
-    Object.defineProperty(oig.viewModels, 'binding', {
-      configurable: true,
-      get: function () {
-        return viewModel;
-      }
-    });
+    sandbox = sinon.sandbox.create();
+    oigViewModelResolver = oigLocator.resolve('oigViewModelResolver');
   });
 
   after(function () {
@@ -42,7 +42,7 @@ describe('binding element', function () {
     viewModel = {
       name: 'John Doe'
     };
-
+    sandbox.stub(oigViewModelResolver, 'resolve').returns(viewModel);
     parent = document.createElement('div');
     var html = '<div xmlns="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink" is="oig-context" data-view-model="binding">' +
       '<oig-binding name="name">name</oig-binding>' +
@@ -53,6 +53,9 @@ describe('binding element', function () {
     bindingElement = element.firstElementChild;
   });
 
+  afterEach(function () {
+    sandbox.restore();
+  });
 
   describe('binding', function () {
     beforeEach(function () {

--- a/test/spec/oig/elements/contextelementSpec.js
+++ b/test/spec/oig/elements/contextelementSpec.js
@@ -10,7 +10,18 @@ describe('context element', function () {
    */
   var viewModel;
 
-  before(function (done) {
+  /**
+   * @type {Object}
+   */
+  var oigViewModelResolver;
+
+  /**
+   * @type {Object}
+   */
+  var sandbox;
+
+  beforeEach(function (done) {
+
     viewModel = {
       name: 'some viewmodel',
       onload: function () {
@@ -19,9 +30,9 @@ describe('context element', function () {
       }
     };
 
-    Object.defineProperty(oig.viewModels, 'me', {
-      value: viewModel
-    });
+    sandbox = sinon.sandbox.create();
+    oigViewModelResolver = oigLocator.resolve('oigViewModelResolver');
+    sandbox.stub(oigViewModelResolver, 'resolve').returns(viewModel);
 
     node = document.createElement('div', 'oig-context');
     node.setAttribute('data-view-model', 'me');
@@ -30,6 +41,7 @@ describe('context element', function () {
   });
 
   afterEach(function () {
+    sandbox.restore();
     if (node.parentNode) {
       node.parentNode.removeChild(node);
     }
@@ -45,7 +57,7 @@ describe('context element', function () {
     });
 
     it('should set the dataContext to the element', function () {
-      expect(node.dataContext).to.equal(oig.viewModels.me);
+      expect(node.dataContext).to.equal(viewModel);
     });
   });
 

--- a/test/spec/oig/elements/ifelementSpec.js
+++ b/test/spec/oig/elements/ifelementSpec.js
@@ -17,13 +17,23 @@ describe('if element', function () {
    * @type {Object}
    */
   var viewModel;
+  /**
+   * @type {Object}
+   */
+  var oigViewModelResolver;
+  /**
+   * @type {Object}
+   */
+  var sandbox;
 
-  before(function () {
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create();
     viewModel = {
       flag: true
     };
-    oig.viewModels.ifViewModel = viewModel;
-  })
+    oigViewModelResolver = oigLocator.resolve('oigViewModelResolver');
+    sandbox.stub(oigViewModelResolver, 'resolve').returns(viewModel);
+  });
 
   beforeEach(function () {
     parent = document.createElement('div', 'oig-context');
@@ -33,6 +43,7 @@ describe('if element', function () {
   });
 
   afterEach(function () {
+    sandbox.restore();
     parent.parentNode && parent.parentNode.removeChild(parent);
   });
 

--- a/test/spec/oig/elements/listenerelementSpec.js
+++ b/test/spec/oig/elements/listenerelementSpec.js
@@ -11,8 +11,9 @@ describe('listener element', function () {
     listener,
     button,
     secondaryButton,
-    viewModel = {};
-
+    viewModel = {},
+    oigViewModelResolver,
+    sandbox;
 
   function dispatch(element, eventType) {
     var event = document.createEvent('CustomEvent');
@@ -21,23 +22,22 @@ describe('listener element', function () {
     return event;
   }
 
+  before(function () {
+    sandbox = sinon.sandbox.create();
+    oigViewModelResolver = oigLocator.resolve('oigViewModelResolver');
+  });
+
   /**
    * setup
    */
-  before(function () {
-    Object.defineProperty(oig.viewModels, 'listenerelement', {
-      configurable: true,
-      get: function () {
-        return viewModel;
-      }
-    });
+  beforeEach(function () {
     viewModel = {};
+    sandbox.stub(oigViewModelResolver, 'resolve').returns(viewModel);
   });
 
   beforeEach(function () {
     viewModel.clickedCallback = sinon.spy();
   });
-
 
   beforeEach(function () {
     node = document.createElement('div', 'oig-context');
@@ -54,6 +54,7 @@ describe('listener element', function () {
   });
 
   afterEach(function () {
+    sandbox.restore();
     node.parentNode && node.parentNode.removeChild(node);
   });
 

--- a/test/spec/oig/elements/reactElementSpec.js
+++ b/test/spec/oig/elements/reactElementSpec.js
@@ -19,17 +19,22 @@ describe('react element', function () {
   var component;
   var componentImpl;
 
+  /**
+   * @type {Object}
+   */
+  var oigViewModelResolver;
+
+  /**
+   * @type {Object}
+   */
+  var sandbox;
+
   before(function () {
-    Object.defineProperty(oig.viewModels, 'reactelement', {
-      configurable: true,
-      get: function () {
-        return viewModel;
-      }
-    });
+    sandbox = sinon.sandbox.create();
+    oigViewModelResolver = oigLocator.resolve('oigViewModelResolver');
   });
 
   after(function () {
-    delete oig.viewModels.reactelement;
     delete window.React;
     delete window.MyJSX;
   });
@@ -43,10 +48,11 @@ describe('react element', function () {
     viewModel = {
       person: {name: "John Doe"}
     };
-
+    sandbox.stub(oigViewModelResolver, 'resolve').returns(viewModel);
   });
 
   afterEach(function () {
+    sandbox.restore();
     parent.parentNode && parent.parentNode.removeChild(parent);
   });
 

--- a/test/spec/oig/elements/templateelementSpec.js
+++ b/test/spec/oig/elements/templateelementSpec.js
@@ -21,13 +21,20 @@ describe('template element', function () {
   var defaultTemplateEngine;
   var customTemplateEngine;
 
+  /**
+   * @type {Object}
+   */
+  var oigViewModelResolver;
+
+  /**
+   * @type {Object}
+   */
+  var sandbox;
+
   before(function () {
-    Object.defineProperty(oig.viewModels, 'templateelement', {
-      configurable: true,
-      get: function () {
-        return viewModel;
-      }
-    });
+    sandbox = sinon.sandbox.create();
+    oigViewModelResolver = oigLocator.resolve('oigViewModelResolver');
+
     customTemplateEngine = {
       compile: sinon.stub()
     };
@@ -57,6 +64,7 @@ describe('template element', function () {
     viewModel = {
       count: 0
     };
+    sandbox.stub(oigViewModelResolver, 'resolve').returns(viewModel);
   });
 
   beforeEach(function () {
@@ -64,6 +72,7 @@ describe('template element', function () {
   });
 
   afterEach(function () {
+    sandbox.restore();
     defaultTemplateEngine.restore();
   });
 


### PR DESCRIPTION
Add OigViewModelResolver for resolving viewModels.
Remove direct defining of viewModel on oig
Fix unit tests and examples
Rename reactElementSpec.js to reactelementSpec.js for file names consistency.